### PR TITLE
Plans on weights?

### DIFF
--- a/index.css
+++ b/index.css
@@ -2,8 +2,7 @@
   font-family: "Cal Sans";
   font-style: normal;
   font-display: swap;
-  font-weight: 600;
-  src: url("./fonts/webfonts/CalSans-SemiBold.woff2") format("woff2"),
-    url("./fonts/webfonts/CalSans-SemiBold.woff") format("woff"),
-    url("./fonts/webfonts/CalSans-SemiBold.ttf") format("truetype");
+  font-weight: 400 700;
+  src: url("./fonts/calsans-var-full/CalSans-VariableFont.woff2") format("woff2"),
+    url("./fonts/calsans-var-full/CalSans-VariableFont.ttf") format("truetype");
 }

--- a/package.json
+++ b/package.json
@@ -7,9 +7,8 @@
   "repository": "https://github.com/calendso/font.git",
   "bugs": "https://github.com/calendso/font/issues",
   "files": [
-    "fonts/webfonts/*.ttf",
-    "fonts/webfonts/*.woff2",
-    "fonts/webfonts/*.woff",
+    "fonts/calsans-var-full/*.ttf",
+    "fonts/calsans-var-full/*.woff2",
     "index.css"
   ],
   "main": "index.css",


### PR DESCRIPTION
## Summary

Update the npm package entry point (`index.css`) and package manifest (`package.json`) to expose the full weight range (400–700) via the variable font. The previous configuration referenced a non-existent `fonts/webfonts/` directory and only declared a single static SemiBold (600) weight — a leftover from v1 before weights were added.

## Changes

- `index.css` — Replace the single-weight static `@font-face` with a variable font declaration using `font-weight: 400 700` range, sourcing from `fonts/calsans-var-full/CalSans-VariableFont.woff2` (with TTF fallback).
- `package.json` — Update `"files"` array to point to the actual variable font location (`fonts/calsans-var-full/`) instead of the non-existent `fonts/webfonts/` directory.

## Test Plan

- `python3 -c "import json; json.load(open('package.json'))"` → valid JSON, exits 0
- `file fonts/calsans-var-full/CalSans-VariableFont.woff2` → confirms WOFF2 font file exists
- Manual: consumers importing `cal-sans` now get all weights (Regular 400, Medium 500, SemiBold 600, Bold 700) through a single variable font file with `font-optical-sizing: auto` support

## Notes

The variable font includes all axes (`opsz`, `GEOM`, `wght`, `YTAS`, `SHRP`, `ital`), giving npm consumers access to the full design space — not just weight. The `font-weight: 400 700` range declaration enables the browser to use any weight in that range without additional `@font-face` rules.

Closes #2
