### PR TITLE
Update: NPM package commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ Cal Sans (v1.000, 2021) was a single static weight built for display — tight, 
 
 ```sh
 # using npm
-npm install cal-sans
+npm install @calcom/cal-sans-ui
 
 # using yarn
-yarn add cal-sans
+yarn add @calcom/cal-sans-ui
 ```
 
 ## Example Usage


### PR DESCRIPTION
Updated `npm` and `yarn` package command as `cal-sans` package no more exist. Which was republished as `@calcom/cal-sans-ui`.