### PR TITLE
docs: add Next.js App Router usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ font-optical-sizing: auto;
 
 That's the whole integration. The font handles the rest.
 
+Using a bundler like Next.js? See [Using Cal Sans with the Next.js App Router](documentation/nextjs.md) for a `next/font/local` + Tailwind setup.
+
 Commissioned by Peer Richelsen for [Cal.com](https://cal.com). Drawn, engineered, and shipped by [WORDMARK](https://wordmark.nyc). Free for commercial and personal use, thanks to the [SIL Open Font License, Version 1.1](#license).
 
 ## Made for humans.

--- a/documentation/nextjs.md
+++ b/documentation/nextjs.md
@@ -1,0 +1,74 @@
+# Using Cal Sans with the Next.js App Router
+
+Cal Sans ships as a single variable font (`CalSansVF.woff2` / `CalSansVF.ttf`), so it works well with
+[`next/font/local`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts#local-fonts) —
+one font file, self-hosted, no layout shift, no request to Google Fonts at runtime.
+
+## 1. Install
+
+```bash
+npm install cal-sans
+```
+
+## 2. Copy the variable font into your app
+
+`next/font/local` needs a file path it can bundle, so copy the variable font out of
+`node_modules` and into your project once (re-run this after upgrading the package):
+
+```bash
+mkdir -p src/assets/fonts
+cp node_modules/cal-sans/fonts/calsans-var-full/CalSansVF.woff2 src/assets/fonts/
+```
+
+## 3. Load it in `app/layout.tsx`
+
+```tsx
+// app/layout.tsx
+import localFont from "next/font/local";
+
+const calSans = localFont({
+  src: "../src/assets/fonts/CalSansVF.woff2",
+  variable: "--font-cal-sans",
+  weight: "400 700", // the font's whole wght axis range — pick any value in between
+  display: "swap",
+});
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" className={calSans.variable}>
+      <body>{children}</body>
+    </html>
+  );
+}
+```
+
+Because `CalSansVF.woff2` is a variable font, `weight: "400 700"` gives you every weight in
+that range from one file — no separate imports per weight.
+
+## 4. Wire it into Tailwind
+
+```ts
+// tailwind.config.ts
+import { fontFamily } from "tailwindcss/defaultTheme";
+
+export default {
+  theme: {
+    extend: {
+      fontFamily: {
+        cal: ["var(--font-cal-sans)", ...fontFamily.sans],
+      },
+    },
+  },
+};
+```
+
+```tsx
+<h1 className="font-cal">Scheduling infrastructure for everyone.</h1>
+```
+
+## Notes
+
+- `font-optical-sizing: auto` (on by default in modern browsers) lets the `opsz` axis respond to
+  `font-size` automatically — no extra setup needed.
+- For the other variable axes (`GEOM`, `YTAS`, `SHRP`, `ital`) and the static, single-weight
+  cuts under `fonts/`, see the main [README](../README.md) and [fonts/README](../fonts/README.md).


### PR DESCRIPTION
## Summary

Adds `documentation/nextjs.md`, a step-by-step guide for using Cal Sans in a Next.js App Router project via `next/font/local` (self-hosted, no layout shift), plus a Tailwind `fontFamily` wiring example. Linked from the README next to the existing plain-CSS usage snippet.

This follows up on the working solution worked out in #6, updated for the current v2 package (single variable font at `fonts/calsans-var-full/CalSansVF.woff2` covering the full 400–700 weight range, rather than the old single static weight).

## Test plan

- [x] Rendered the markdown locally to check formatting/links
- [x] Verified the referenced package paths (`cal-sans` → `fonts/calsans-var-full/CalSansVF.woff2`) match what's actually published in `package.json` / `fonts/`
- [ ] Would appreciate a maintainer sanity-check that `next/font/local` + variable-font `weight: "400 700"` matches how you'd recommend consuming it

Closes #6